### PR TITLE
use Tz data so last update time shows correctly

### DIFF
--- a/custom_components/kia_uvo/Vehicle.py
+++ b/custom_components/kia_uvo/Vehicle.py
@@ -1,5 +1,6 @@
 import logging
 
+import pytz
 import re
 import requests
 from datetime import datetime, timezone
@@ -83,11 +84,12 @@ class Vehicle(object):
         self.token = self.kia_uvo_api.login()
 
     def set_last_updated(self):
+        kia_tz = pytz.timezone("Europe/Paris")
         m = re.match(
             r"(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})",
             self.vehicle_data["vehicleStatus"]["time"],
         )
-        self.last_updated = datetime(
+        _last_updated = datetime(
             year = int(m.group(1)),
             month = int(m.group(2)),
             day = int(m.group(3)),
@@ -95,6 +97,7 @@ class Vehicle(object):
             minute = int(m.group(5)),
             second = int(m.group(6)),
         )
+        self.last_updated = kia_tz.localize(_last_updated)
     
     def set_engine_type(self):
         if "dte" in self.vehicle_data["vehicleStatus"]:

--- a/custom_components/kia_uvo/Vehicle.py
+++ b/custom_components/kia_uvo/Vehicle.py
@@ -84,7 +84,6 @@ class Vehicle(object):
         self.token = self.kia_uvo_api.login()
 
     def set_last_updated(self):
-        kia_tz = pytz.timezone("Europe/Paris")
         m = re.match(
             r"(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})",
             self.vehicle_data["vehicleStatus"]["time"],
@@ -97,7 +96,7 @@ class Vehicle(object):
             minute = int(m.group(5)),
             second = int(m.group(6)),
         )
-        self.last_updated = kia_tz.localize(_last_updated)
+        self.last_updated = KIA_TZ.localize(_last_updated)
     
     def set_engine_type(self):
         if "dte" in self.vehicle_data["vehicleStatus"]:

--- a/custom_components/kia_uvo/__init__.py
+++ b/custom_components/kia_uvo/__init__.py
@@ -17,7 +17,7 @@ from .const import *
 from .Token import Token
 from .Vehicle import Vehicle
 from .KiaUvoApi import KiaUvoApi
-from datetime import datetime
+from datetime import datetime, timezone
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -80,9 +80,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         await vehicle.update()
         if (event_time.hour < NO_FORCE_SCAN_HOUR_START and event_time.hour >= NO_FORCE_SCAN_HOUR_FINISH):
             _LOGGER.debug(f"{DOMAIN} - We are in force hour zone {event_time}")
-            _LOGGER.debug(f"{DOMAIN} - Check last update of vehicle {vehicle.last_updated} {datetime.now()} {FORCE_SCAN_INTERVAL} {datetime.now() - vehicle.last_updated > FORCE_SCAN_INTERVAL}")
+            _LOGGER.debug(f"{DOMAIN} - Check last update of vehicle {vehicle.last_updated} {datetime.now(timezone.utc)} {FORCE_SCAN_INTERVAL} {datetime.now(timezone.utc) - vehicle.last_updated > FORCE_SCAN_INTERVAL}")
 
-            if datetime.now() - vehicle.last_updated > FORCE_SCAN_INTERVAL:
+            if datetime.now(timezone.utc) - vehicle.last_updated > FORCE_SCAN_INTERVAL:
                 try:
                     await vehicle.force_update()
                 except Exception as ex:

--- a/custom_components/kia_uvo/__init__.py
+++ b/custom_components/kia_uvo/__init__.py
@@ -80,9 +80,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         await vehicle.update()
         if (event_time.hour < NO_FORCE_SCAN_HOUR_START and event_time.hour >= NO_FORCE_SCAN_HOUR_FINISH):
             _LOGGER.debug(f"{DOMAIN} - We are in force hour zone {event_time}")
-            _LOGGER.debug(f"{DOMAIN} - Check last update of vehicle {vehicle.last_updated} {datetime.now(timezone.utc)} {FORCE_SCAN_INTERVAL} {datetime.now(timezone.utc) - vehicle.last_updated > FORCE_SCAN_INTERVAL}")
+            _LOGGER.debug(f"{DOMAIN} - Check last update of vehicle {UTC_TZ.normalize(vehicle.last_updated)} {datetime.now(timezone.utc)} {FORCE_SCAN_INTERVAL} {datetime.now(timezone.utc) - UTC_TZ.normalize(vehicle.last_updated) > FORCE_SCAN_INTERVAL}")
 
-            if datetime.now(timezone.utc) - vehicle.last_updated > FORCE_SCAN_INTERVAL:
+            if datetime.now(timezone.utc) - UTC_TZ.normalize(vehicle.last_updated) > FORCE_SCAN_INTERVAL:
                 try:
                     await vehicle.force_update()
                 except Exception as ex:

--- a/custom_components/kia_uvo/const.py
+++ b/custom_components/kia_uvo/const.py
@@ -2,6 +2,7 @@ import logging
 
 from enum import Enum
 from datetime import timedelta
+import pytz
 
 from homeassistant.const import LENGTH_KILOMETERS, LENGTH_MILES
 
@@ -34,6 +35,9 @@ SCAN_AFTER_LOCK_INTERVAL = 30
 SCAN_AFTER_LOCK_COUNT = 5
 NO_FORCE_SCAN_HOUR_START = 22
 NO_FORCE_SCAN_HOUR_FINISH = 6
+
+KIA_TZ = pytz.timezone('CET')
+UTC_TZ = pytz.timezone('UTC')
 
 NOT_APPLICABLE = "Not Applicable"
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S.%f"


### PR DESCRIPTION
Time data seems to come in Western European time -
![image](https://user-images.githubusercontent.com/61918526/114467650-22947180-9be2-11eb-9e1d-db25813d8aa7.png)

This was previously causing the last update time to show as "In 30 minutes" for example, for me in the UK, as the time often looked like it was in the future.

This adds Tz data to the last update time, so the system can work out local time and display this
![image](https://user-images.githubusercontent.com/61918526/114467619-17414600-9be2-11eb-875d-560859046807.png)
![image](https://user-images.githubusercontent.com/61918526/114467701-38099b80-9be2-11eb-87b9-7b12984c784a.png)
![image](https://user-images.githubusercontent.com/61918526/114468001-b36b4d00-9be2-11eb-8bfc-75b9b19f1b37.png)
