### PR TITLE
Add iot_class to manifest

### DIFF
--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -6,5 +6,6 @@
     "@fuatakgun"
   ],
   "version": "0.0.1",
-  "config_flow": true
+  "config_flow": true,
+  "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
I've got a few other integrations that use the [Hassfest](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) github action to validate the integration. These all started failing a couple of days ago due to lack of [iot_class](https://developers.home-assistant.io/docs/creating_integration_manifest/#iot-class)  in the manifest. So I'm adding this here to, as I guess it is going to become a requirement