### PR TITLE
Move where dynamic unit is enumerated

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -70,14 +70,6 @@ class InstrumentSensor(KiaUvoEntity):
         self._icon = icon
         self._device_class = device_class
 
-        if self._unit == UNIT_IS_DYNAMIC:
-            key_unit = key.replace(".value", ".unit")
-            found_unit = self.getChildValue(self.vehicle.vehicle_data, key_unit)
-            if found_unit in DISTANCE_UNITS:
-                self._unit = DISTANCE_UNITS[found_unit]
-            else:
-                self._unit = NOT_APPLICABLE
-
     @property
     def state(self):
         if self._id == "lastUpdated":
@@ -92,6 +84,14 @@ class InstrumentSensor(KiaUvoEntity):
 
     @property
     def unit_of_measurement(self):
+        if self._unit == UNIT_IS_DYNAMIC:
+            key_unit = self._key.replace(".value", ".unit")
+            found_unit = self.getChildValue(self.vehicle.vehicle_data, key_unit)
+            if found_unit in DISTANCE_UNITS:
+                self._unit = DISTANCE_UNITS[found_unit]
+            else:
+                self._unit = NOT_APPLICABLE
+
         return self._unit
 
     @property


### PR DESCRIPTION
The range data coming from Kia is a bit all over the place :-) sometimes I get the distance km, and then after I do a force refresh in Home Assistant I get the distance in miles (which is what I have set on the Kia UVO iOS app settings). 

But the units displayed in the integrations weren't updating as it was working them out in the init code, rather than on each update. So in the examples below, the range is first 277km, and then after the force update 172 miles, but it still says km.

Before force update:
![Capture_ev_range_before_update](https://user-images.githubusercontent.com/61918526/116759383-1c87f880-aa0a-11eb-9fb3-1bb762f93182.PNG)

After force update:
![Capture_ev_range_after_update](https://user-images.githubusercontent.com/61918526/116759409-2b6eab00-aa0a-11eb-907c-e62673146808.PNG)
 
