### PR TITLE
Make sure dynamic UoM sensors units are not only checked the first time

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -69,6 +69,7 @@ class InstrumentSensor(KiaUvoEntity):
         self._unit = unit
         self._icon = icon
         self._device_class = device_class
+        self._initial_unit = None
 
     @property
     def state(self):
@@ -84,7 +85,9 @@ class InstrumentSensor(KiaUvoEntity):
 
     @property
     def unit_of_measurement(self):
-        if self._unit == UNIT_IS_DYNAMIC:
+        if self._initial_unit == None:
+            self._initial_unit = self._unit
+        if self._initial_unit == UNIT_IS_DYNAMIC:
             key_unit = self._key.replace(".value", ".unit")
             found_unit = self.getChildValue(self.vehicle.vehicle_data, key_unit)
             if found_unit in DISTANCE_UNITS:


### PR DESCRIPTION
Needed to make an extra little change so that the dynamic units of measurement sensors had their units updated each time rather than only the first loop around.