### PR TITLE
fix: Niro 2019 EV being labeled PHEV

### DIFF
--- a/custom_components/kia_uvo/Vehicle.py
+++ b/custom_components/kia_uvo/Vehicle.py
@@ -204,13 +204,16 @@ class Vehicle(object):
         self.last_updated = last_updated
 
     def set_engine_type(self):
-        if "evStatus" in self.vehicle_data["vehicleStatus"] and "lowFuelLight" in self.vehicle_data["vehicleStatus"]:
-            self.engine_type = VEHICLE_ENGINE_TYPE.PHEV
+        if "evStatus" in self.vehicle_data["vehicleStatus"] and self.token.vehicle_model.endswith(" EV"):
+            self.engine_type = VEHICLE_ENGINE_TYPE.EV
         else:
-            if "evStatus" in self.vehicle_data["vehicleStatus"]:
-                self.engine_type = VEHICLE_ENGINE_TYPE.EV
+            if "evStatus" in self.vehicle_data["vehicleStatus"] and "lowFuelLight" in self.vehicle_data["vehicleStatus"]:
+                self.engine_type = VEHICLE_ENGINE_TYPE.PHEV
             else:
-                self.engine_type = VEHICLE_ENGINE_TYPE.IC
+                if "evStatus" in self.vehicle_data["vehicleStatus"]:
+                    self.engine_type = VEHICLE_ENGINE_TYPE.EV
+                else:
+                    self.engine_type = VEHICLE_ENGINE_TYPE.IC
         _LOGGER.debug(f"{DOMAIN} - Engine type set {self.engine_type}")
 
     def get_child_value(self, key):


### PR DESCRIPTION
because it does have a lowFuelLight and is an EV

happy to switch to better implementation, this seemed the least invasive change

maybe if we compared vehicle data we could see a pattern in the more explicit attributes like driveType or fuelType

for reference
```
'{"status":{"statusCode":0,"errorType":0,"errorCode":0,"errorMessage":"Success with response body"},"payload":{"vehicleInfoList":[{"vinKey":"kkk","vehicleConfig":{"vehicleDetail":{"vehicle":{"vin":"vvv","trim":{"modelYear":"2019","salesModelCode":"V1262","optionGroupCode":"015","modelName":"NIRO EV","factoryCode":"DQ","projectCode":"DEEV","trimName":"EX PREMIUM","driveType":"0","transmissionType":"1","ivrCategory":"6","btSeriesCode":"N"},"telematics":1,"mileage":"12110.8","mileageSyncDate":"20211107085034","exteriorColor":"ALUMINUM SILVER","exteriorColorCode":"C3S","fuelType":4,"invDealerCode":"MD047","testVehicle":"0","supportedApps":[{"appType":"0"},{"appType":"5","appImage":{"imageName":"uvo-app.png","imagePath":"/content/dam/kia/us/owners/image/common/app/access/","imageType":"2","imageSize":{"length":"100","width":"100","uom":0}}}],"activationType":2},"images":[{"imageName":"2019-niro_ev-ex_premium-c3s.png","imagePath":"/content/dam/kia/us/owners/image/vehicle/2019/niro_ev/ex_premium/","imageType":"1","imageSize":{"length":"100","width":"100","uom":0}}],"device":{"launchType":"0","swVersion":"DEEV.USA.SOP.V105.190503.STD_H","telematics":{"generation":"3","platform":"1","tmsCenter":"1","billing":true},"versionNum":"ECO","headUnitType":"0","hdRadio":"X40HA","ampType":"NA","modem":{"meid":"354522081158920","mdn":"6573652075","iccid":"89148000005051202869"},"headUnitName":"avn40ev_np","bluetoothRef":"10","headUnitDesc":"AVN5.0"}},"billingPeriod":{"freeTrial":{"value":12,"unit":0},"freeTrialExtension":{"value":12,"unit":1},"servicePeriod":{"value":60,"unit":1}}},"lastVehicleInfo":{"vehicleNickName":"Niro EV","preferredDealer":"MD047","customerType":0,"enrollment":{"provStatus":"4","enrollmentStatus":"1","enrollmentType":"0","registrationDate":"20191123","expirationDate":"20201122","expirationMileage":"100000","freeServiceDate":{"startDate":"20191122","endDate":"20201122"}},"activeDTC":{"dtcActiveCount":"0"},"vehicleStatusRpt":{"statusType":"2","reportDate":{"utc":"20211108004231","offset":-8},"vehicleStatus":{"climate":{"airCtrl":false,"defrost":false,"airTemp":{"value":"72","unit":1},"heatingAccessory":{"steeringWheel":0,"sideMirror":0,"rearWindow":0}},"engine":false,"doorLock":true,"doorStatus":{"frontLeft":0,"frontRight":0,"backLeft":0,"backRight":0,"trunk":0,"hood":0},"lowFuelLight":false,"evStatus":{"batteryCharge":true,"batteryStatus":70,"batteryPlugin":2,"remainChargeTime":[{"remainChargeType":3,"timeInterval":{"value":160,"unit":4}}],"drvDistance":[{"type":2,"rangeByFuel":{"evModeRange":{"value":197,"unit":3},"totalAvailableRange":{"value":197,"unit":3}}}],"syncDate":{"utc":"20211107235034","offset":-8},"targetSOC":[{"plugType":0,"targetSOClevel":90,"dte":{"type":2,"rangeByFuel":{"gasModeRange":{"value":0,"unit":3},"evModeRange":{"value":197,"unit":3},"totalAvailableRange":{"value":197,"unit":3}}}},{"plugType":1,"targetSOClevel":90,"dte":{"type":2,"rangeByFuel":{"gasModeRange":{"value":0,"unit":3},"evModeRange":{"value":197,"unit":3},"totalAvailableRange":{"value":197,"unit":3}}}}]},"ign3":true,"transCond":true,"tirePressure":{"all":0},"dateTime":{"utc":"20211108004231","offset":-8},"syncDate":{"utc":"20211107235034","offset":-8},"batteryStatus":{"stateOfCharge":87,"sensorStatus":0},"sleepMode":false,"lampWireStatus":{"headLamp":{},"stopLamp":{},"turnSignalLamp":{}},"windowStatus":{},"engineRuntime":{},"valetParkingMode":0}},"location":{"coord":{"lat":30,"lon":-70,"alt":76,"type":0,"altdo":0},"head":345,"speed":{"value":0,"unit":1},"accuracy":{"hdop":6,"pdop":12},"syncDate":{"utc":"20211107235034","offset":-8}},"financed":true,"financeRegistered":true,"linkStatus":0}}]}}'
```