### PR TITLE
fix: odometer value of 19518.4 error

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -53,7 +53,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     sensors = []
 
     for id, description, key, unit, icon, device_class in INSTRUMENTS:
-        if vehicle.get_child_value(key) != None:
+        if vehicle.get_child_value(key) is None:
+            _LOGGER.debug(f"skipping sensor for missing data, key:{key}")
+        else:
             sensors.append(InstrumentSensor(hass, config_entry, vehicle, id, description, key, unit, icon, device_class))
 
     sensors.append(InstrumentSensor(hass, config_entry, vehicle, "lastUpdated", "Last Update", "last_updated", "None", "mdi:update", DEVICE_CLASS_TIMESTAMP))
@@ -101,7 +103,7 @@ class InstrumentSensor(KiaUvoEntity):
             value = NOT_APPLICABLE
         else:
             if self._source_unit != self._unit:
-                value = distance_util.convert(value, self._source_unit, self._unit)
+                value = distance_util.convert(float(value), self._source_unit, self._unit)
             if isinstance(value, float) == True:
                 value = round(value, 1)
 


### PR DESCRIPTION
fix based on stack trace of, added debug logging for absent sensors as I'm hoping this is an easy pr to merge
```
2021-11-09 12:27:33 ERROR (MainThread) [homeassistant.components.sensor] Error while setting up kia_uvo platform for sensor
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 257, in _async_setup_platform
    await asyncio.gather(*pending)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 382, in async_add_entities
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 607, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 715, in add_to_platform_finish
    self.async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 486, in async_write_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 519, in _async_write_ha_state
    state = self._stringify_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 492, in _stringify_state
    if (state := self.state) is None:
  File "/config/custom_components/kia_uvo/sensor.py", line 110, in state
    value = distance_util.convert(value, self._source_unit, self._unit)
  File "/usr/src/homeassistant/homeassistant/util/distance.py", line 62, in convert
    raise TypeError(f"{value} is not of numeric type")
TypeError: 12128.2 is not of numeric type
```