### PR TITLE
fix: reduce force refreshing when not needed

### DIFF
--- a/custom_components/kia_uvo/KiaUvoAPIUSA.py
+++ b/custom_components/kia_uvo/KiaUvoAPIUSA.py
@@ -12,21 +12,15 @@ import time
 
 from .const import (
     DOMAIN,
-    BRANDS,
-    BRAND_HYUNDAI,
-    BRAND_KIA,
     DATE_FORMAT,
-    VEHICLE_LOCK_ACTION,
 )
 from .KiaUvoApiImpl import KiaUvoApiImpl
 from .Token import Token
 
 _LOGGER = logging.getLogger(__name__)
 
-
 class AuthError(RequestException):
     pass
-
 
 def request_with_active_session(func):
     def request_with_active_session_wrapper(*args, **kwargs):
@@ -87,6 +81,7 @@ class KiaUvoAPIUSA(KiaUvoApiImpl):
         super().__init__(
             username, password, region, brand, use_email_with_geocode_api, pin
         )
+        self.synchronous_actions = True
 
         # Randomly generate a plausible device id on startup
         self.device_id = (

--- a/custom_components/kia_uvo/KiaUvoAPIUSA.py
+++ b/custom_components/kia_uvo/KiaUvoAPIUSA.py
@@ -19,8 +19,10 @@ from .Token import Token
 
 _LOGGER = logging.getLogger(__name__)
 
+
 class AuthError(RequestException):
     pass
+
 
 def request_with_active_session(func):
     def request_with_active_session_wrapper(*args, **kwargs):

--- a/custom_components/kia_uvo/KiaUvoApiEU.py
+++ b/custom_components/kia_uvo/KiaUvoApiEU.py
@@ -56,10 +56,26 @@ class KiaUvoApiEU(KiaUvoApiImpl):
 
         if BRANDS[brand] == BRAND_KIA:
             auth_client_id = "f4d531c7-1043-444d-b09a-ad24bd913dd4"
-            self.LOGIN_FORM_URL: str = "https://" + self.LOGIN_FORM_HOST + "/auth/realms/eukiaidm/protocol/openid-connect/auth?client_id=" + auth_client_id + "&scope=openid%20profile%20email%20phone&response_type=code&hkid_session_reset=true&redirect_uri=" + self.USER_API_URL + "integration/redirect/login&ui_locales=en&state=$service_id:$user_id"
+            self.LOGIN_FORM_URL: str = (
+                "https://"
+                + self.LOGIN_FORM_HOST
+                + "/auth/realms/eukiaidm/protocol/openid-connect/auth?client_id="
+                + auth_client_id
+                + "&scope=openid%20profile%20email%20phone&response_type=code&hkid_session_reset=true&redirect_uri="
+                + self.USER_API_URL
+                + "integration/redirect/login&ui_locales=en&state=$service_id:$user_id"
+            )
         elif BRANDS[brand] == BRAND_HYUNDAI:
             auth_client_id = "64621b96-0f0d-11ec-82a8-0242ac130003"
-            self.LOGIN_FORM_URL: str = "https://" + self.LOGIN_FORM_HOST + "/auth/realms/euhyundaiidm/protocol/openid-connect/auth?client_id=" + auth_client_id + "&scope=openid%20profile%20email%20phone&response_type=code&hkid_session_reset=true&redirect_uri=" + self.USER_API_URL + "integration/redirect/login&ui_locales=en&state=$service_id:$user_id"
+            self.LOGIN_FORM_URL: str = (
+                "https://"
+                + self.LOGIN_FORM_HOST
+                + "/auth/realms/euhyundaiidm/protocol/openid-connect/auth?client_id="
+                + auth_client_id
+                + "&scope=openid%20profile%20email%20phone&response_type=code&hkid_session_reset=true&redirect_uri="
+                + self.USER_API_URL
+                + "integration/redirect/login&ui_locales=en&state=$service_id:$user_id"
+            )
 
         self.stamps_url: str = (
             "https://raw.githubusercontent.com/neoPix/bluelinky-stamps/master/"
@@ -241,7 +257,10 @@ class KiaUvoApiEU(KiaUvoApiImpl):
             "credentialId": "",
             "rememberMe": "on",
         }
-        headers = {"Content-Type": "application/x-www-form-urlencoded", "User-Agent": USER_AGENT_MOZILLA}
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "User-Agent": USER_AGENT_MOZILLA,
+        }
         response = requests.post(
             login_form_action_url,
             data=data,
@@ -270,27 +289,39 @@ class KiaUvoApiEU(KiaUvoApiImpl):
         intUserId = 0
         if "account-find-link" in response.text:
             soup = BeautifulSoup(response.content, "html.parser")
-            login_form_action_url = soup.find("form")["action"].replace("&amp;","&")
+            login_form_action_url = soup.find("form")["action"].replace("&amp;", "&")
             data = {"actionType": "FIND", "createToUVO": "UVO", "email": ""}
-            headers = {"Content-Type": "application/x-www-form-urlencoded", "User-Agent": USER_AGENT_MOZILLA}
-            response = requests.post(login_form_action_url, data=data, headers=headers, allow_redirects=False, cookies=self.cookies)
+            headers = {
+                "Content-Type": "application/x-www-form-urlencoded",
+                "User-Agent": USER_AGENT_MOZILLA,
+            }
+            response = requests.post(
+                login_form_action_url,
+                data=data,
+                headers=headers,
+                allow_redirects=False,
+                cookies=self.cookies,
+            )
 
             if response.status_code != 302:
-                _LOGGER.debug(f"{DOMAIN} - AccountFindLink Error {login_form_action_url} - Response {response.status_code}")
+                _LOGGER.debug(
+                    f"{DOMAIN} - AccountFindLink Error {login_form_action_url} - Response {response.status_code}"
+                )
                 return
 
             self.cookies = self.cookies | response.cookies.get_dict()
             redirect_url = response.headers["Location"]
             headers = {"User-Agent": USER_AGENT_MOZILLA}
             response = requests.get(redirect_url, headers=headers, cookies=self.cookies)
-            _LOGGER.debug(f"{DOMAIN} - Redirect User Id 2 {redirect_url} - Response {response.url}")
+            _LOGGER.debug(
+                f"{DOMAIN} - Redirect User Id 2 {redirect_url} - Response {response.url}"
+            )
             _LOGGER.debug(f"{DOMAIN} - Redirect 2 - Response Text {response.text}")
             parsed_url = urlparse(response.url)
             intUserId = "".join(parse_qs(parsed_url.query)["int_user_id"])
         else:
             parsed_url = urlparse(response.url)
             intUserId = "".join(parse_qs(parsed_url.query)["intUserId"])
-
 
         url = self.USER_API_URL + "silentsignin"
         headers = {

--- a/custom_components/kia_uvo/KiaUvoApiImpl.py
+++ b/custom_components/kia_uvo/KiaUvoApiImpl.py
@@ -1,12 +1,6 @@
 import logging
 
-from datetime import datetime
-from datetime import tzinfo
-import push_receiver
-import random
 import requests
-import uuid
-from urllib.parse import parse_qs, urlparse
 
 from homeassistant.util import dt as dt_util
 
@@ -33,6 +27,7 @@ class KiaUvoApiImpl:
         self.stamps = None
         self.region = region
         self.brand = brand
+        self.synchronous_actions = False
 
     def login(self) -> Token:
         pass
@@ -76,6 +71,9 @@ class KiaUvoApiImpl:
 
     def stop_charge(self, token: Token):
         pass
+
+    def synchronous_actions(self) -> bool:
+        self.synchronous_actions
 
     def get_timezone_by_region(self) -> tzinfo:
         if REGIONS[self.region] == REGION_CANADA:

--- a/custom_components/kia_uvo/KiaUvoApiImpl.py
+++ b/custom_components/kia_uvo/KiaUvoApiImpl.py
@@ -72,9 +72,6 @@ class KiaUvoApiImpl:
     def stop_charge(self, token: Token):
         pass
 
-    def synchronous_actions(self) -> bool:
-        self.synchronous_actions
-
     def get_timezone_by_region(self) -> tzinfo:
         if REGIONS[self.region] == REGION_CANADA:
             return dt_util.UTC


### PR DESCRIPTION
related to https://github.com/fuatakgun/kia_uvo/issues/151 this works for the USA kia to avoid calling and waiting to finish the force refresh endpoint since the action is known to have completed and the api has already cached that result. @cdnninja this will probably also work for the CA version but I didn't want to change the impl flag since I can't test it.