### PR TITLE
feat: change actions to run on threads instead of event loop

### DIFF
--- a/custom_components/kia_uvo/__init__.py
+++ b/custom_components/kia_uvo/__init__.py
@@ -76,11 +76,11 @@ async def async_setup(hass: HomeAssistant, config_entry: ConfigEntry):
 
     async def async_handle_force_update(call):
         vehicle: Vehicle = hass.data[DOMAIN][DATA_VEHICLE_INSTANCE]
-        await vehicle.force_update()
+        hass.create_task(vehicle.force_update())
 
     async def async_handle_update(call):
         vehicle: Vehicle = hass.data[DOMAIN][DATA_VEHICLE_INSTANCE]
-        await vehicle.update()
+        hass.create_task(vehicle.update())
 
     async def async_handle_start_climate(call):
         set_temp = call.data.get("Temperature")
@@ -89,19 +89,19 @@ async def async_setup(hass: HomeAssistant, config_entry: ConfigEntry):
         climate = call.data.get("Climate")
         heating = call.data.get("Heating")
         vehicle: Vehicle = hass.data[DOMAIN][DATA_VEHICLE_INSTANCE]
-        await vehicle.start_climate(set_temp, duration, defrost, climate, heating)
+        hass.create_task(vehicle.start_climate(set_temp, duration, defrost, climate, heating))
 
     async def async_handle_stop_climate(call):
         vehicle: Vehicle = hass.data[DOMAIN][DATA_VEHICLE_INSTANCE]
-        await vehicle.stop_climate()
+        hass.create_task(vehicle.stop_climate())
 
     async def async_handle_start_charge(call):
         vehicle: Vehicle = hass.data[DOMAIN][DATA_VEHICLE_INSTANCE]
-        await vehicle.start_charge()
+        hass.create_task(vehicle.start_charge())
 
     async def async_handle_stop_charge(call):
         vehicle: Vehicle = hass.data[DOMAIN][DATA_VEHICLE_INSTANCE]
-        await vehicle.stop_charge()
+        hass.create_task(vehicle.stop_charge())
 
     hass.services.async_register(DOMAIN, "force_update", async_handle_force_update)
     hass.services.async_register(DOMAIN, "update", async_handle_update)

--- a/custom_components/kia_uvo/__init__.py
+++ b/custom_components/kia_uvo/__init__.py
@@ -89,7 +89,9 @@ async def async_setup(hass: HomeAssistant, config_entry: ConfigEntry):
         climate = call.data.get("Climate")
         heating = call.data.get("Heating")
         vehicle: Vehicle = hass.data[DOMAIN][DATA_VEHICLE_INSTANCE]
-        hass.create_task(vehicle.start_climate(set_temp, duration, defrost, climate, heating))
+        hass.create_task(
+            vehicle.start_climate(set_temp, duration, defrost, climate, heating)
+        )
 
     async def async_handle_stop_climate(call):
         vehicle: Vehicle = hass.data[DOMAIN][DATA_VEHICLE_INSTANCE]

--- a/custom_components/kia_uvo/lock.py
+++ b/custom_components/kia_uvo/lock.py
@@ -40,7 +40,7 @@ class Lock(KiaUvoEntity, LockEntity):
         return "mdi:lock" if self.is_locked else "mdi:lock-open-variant"
 
     async def async_lock(self):
-        await self.vehicle.lock_action(VEHICLE_LOCK_ACTION.LOCK)
+        self.hass.create_task(self.vehicle.lock_action(VEHICLE_LOCK_ACTION.LOCK))
 
     async def async_unlock(self):
-        await self.vehicle.lock_action(VEHICLE_LOCK_ACTION.UNLOCK)
+        self.hass.create_task(self.vehicle.lock_action(VEHICLE_LOCK_ACTION.UNLOCK))


### PR DESCRIPTION
1) allows google home lock to be happy
2) frees up event loop time for HA since the HA updates are handled async with signal messaging anyway
3) HA scripts have to wait for states anyway since the actions involve async delays for updates or action status checking which prevents them from being awaited so the final update can't happen synchronously anyway

thoughts? @cdnninja @fuatakgun 