### PR TITLE
fix: Hyundai USA: support a separate location fetch (Issue #196)

### DIFF
--- a/custom_components/kia_uvo/Vehicle.py
+++ b/custom_components/kia_uvo/Vehicle.py
@@ -142,13 +142,19 @@ class Vehicle:
         old_lat = None
         old_lon = None
         old_geocode = None
-        if not old_vehicle_location is None:
+        if (
+            not old_vehicle_location is None
+            and old_vehicle_location.get("coord") is not None
+        ):
             old_lat = old_vehicle_location["coord"]["lat"]
             old_lon = old_vehicle_location["coord"]["lon"]
             old_geocode = old_vehicle_location.get("geocodedLocation", None)
 
         new_lat = self.get_child_value("vehicleLocation.coord.lat")
         new_lon = self.get_child_value("vehicleLocation.coord.lon")
+
+        if self.vehicle_data.get("vehicleLocation") is None:
+            self.vehicle_data["vehicleLocation"] = {}
 
         if (old_lat != new_lat or old_lon != new_lon) or old_geocode is None:
             self.vehicle_data["vehicleLocation"][


### PR DESCRIPTION
The location information provided in the cached vehicle status does not
include decimal precision.  In order to fix this, implement the
get_location method in the api for Hyundai USA.

Considering that there is a daily API limit, poll the get_location
method based on whether or not the odometer changed.  It will also keep
track of the last time that the location was retrieved form the server,
and only fetch a new location if the last update was more than an hour
ago.