### PR TITLE
fix: Duplicate vehicle.refresh_token() call

### DIFF
--- a/custom_components/kia_uvo/__init__.py
+++ b/custom_components/kia_uvo/__init__.py
@@ -193,7 +193,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
     async def update(event_time_utc: datetime):
         await refresh_config_entry()
-        await vehicle.refresh_token()
         local_timezone = vehicle.kia_uvo_api.get_timezone_by_region()
         event_time_local = event_time_utc.astimezone(local_timezone)
         await vehicle.update()


### PR DESCRIPTION
Removed a duplicate vehicle.refresh_token().  This is called in line 195 as refresh_config_entry first refresh's the token.  This is causing duplicate vehicle calls in the USA implementation for Hyundai due to the short token time.