### PR TITLE
fix:  Corrected hex issue impacting 22C Display

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -315,8 +315,6 @@ class InstrumentSensor(KiaUvoEntity):
                     return temp_range[-1]
             else:
                 value = value.replace("H", "")
-                value = value.replace("C", "")
-                value = "0x" + value
                 return temp_range[int(value, 16)]
 
         if value is None:


### PR DESCRIPTION
Example that shows the math error:  Starting value is 22 yet it returns 16.

```
CA_TEMP_RANGE = [
        16,
        16.5,
        17,
        17.5,
        18,
        18.5,
        19,
        19.5,
        20,
        20.5,
        21,
        21.5,
        22,
        22.5,
        23,
        23.5,
        24,
        24.5,
        25,
        25.5,
        26,
        26.5,
        27,
        27.5,
        28,
        28.5,
        29,
        29.5,
        30,
        30.5,
        31,
        31.5,
        32,
]  
set_temp = CA_TEMP_RANGE.index(22)
print(set_temp)
set_temp = hex(set_temp).split("x")

set_temp = set_temp[1] + "H"
set_temp = set_temp.zfill(3).upper()
print(set_temp)

value = set_temp.replace("H", "")
value = value.replace("C", "")
value = "0x" + value
value = CA_TEMP_RANGE[int(value, 16)]
print(value)
```