### PR TITLE
feat: Add long term statistics

### DIFF
--- a/custom_components/kia_uvo/KiaUvoEntity.py
+++ b/custom_components/kia_uvo/KiaUvoEntity.py
@@ -1,59 +1,12 @@
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
-from homeassistant.components.sensor import SensorEntity
 
 from .Vehicle import Vehicle
 from .const import DOMAIN, DATA_VEHICLE_INSTANCE, TOPIC_UPDATE, BRANDS
 
 
 class KiaUvoEntity(Entity):
-    def __init__(self, hass, config_entry, vehicle: Vehicle):
-        self.hass = hass
-        self.config_entry = config_entry
-        self.vehicle = vehicle
-        self.topic_update = TOPIC_UPDATE.format(vehicle.id)
-        self.topic_update_listener = None
-
-    async def async_added_to_hass(self):
-        @callback
-        def update():
-            self.update_from_latest_data()
-            self.async_write_ha_state()
-
-        await super().async_added_to_hass()
-        self.topic_update_listener = async_dispatcher_connect(
-            self.hass, self.topic_update, update
-        )
-        self.async_on_remove(self.topic_update_listener)
-        self.update_from_latest_data()
-
-    @property
-    def available(self) -> bool:
-        return not not self.vehicle
-
-    @property
-    def should_poll(self) -> bool:
-        return False
-
-    @property
-    def device_info(self):
-        return {
-            "identifiers": {(DOMAIN, self.vehicle.id)},
-            "name": self.vehicle.name,
-            "manufacturer": BRANDS[self.vehicle.kia_uvo_api.brand],
-            "model": self.vehicle.model,
-            "engine_type": self.vehicle.engine_type,
-            "sw_version": self.vehicle.registration_date,
-            "via_device": (DOMAIN, self.vehicle.id),
-        }
-
-    @callback
-    def update_from_latest_data(self):
-        self.vehicle = self.hass.data[DOMAIN][DATA_VEHICLE_INSTANCE]
-
-
-class KiaUvoSensorEntity(SensorEntity):
     def __init__(self, hass, config_entry, vehicle: Vehicle):
         self.hass = hass
         self.config_entry = config_entry

--- a/custom_components/kia_uvo/KiaUvoEntity.py
+++ b/custom_components/kia_uvo/KiaUvoEntity.py
@@ -53,7 +53,6 @@ class KiaUvoEntity(Entity):
         self.vehicle = self.hass.data[DOMAIN][DATA_VEHICLE_INSTANCE]
 
 
-
 class KiaUvoSensorEntity(SensorEntity):
     def __init__(self, hass, config_entry, vehicle: Vehicle):
         self.hass = hass

--- a/custom_components/kia_uvo/KiaUvoEntity.py
+++ b/custom_components/kia_uvo/KiaUvoEntity.py
@@ -1,12 +1,60 @@
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
+from homeassistant.components.sensor import SensorEntity
 
 from .Vehicle import Vehicle
 from .const import DOMAIN, DATA_VEHICLE_INSTANCE, TOPIC_UPDATE, BRANDS
 
 
 class KiaUvoEntity(Entity):
+    def __init__(self, hass, config_entry, vehicle: Vehicle):
+        self.hass = hass
+        self.config_entry = config_entry
+        self.vehicle = vehicle
+        self.topic_update = TOPIC_UPDATE.format(vehicle.id)
+        self.topic_update_listener = None
+
+    async def async_added_to_hass(self):
+        @callback
+        def update():
+            self.update_from_latest_data()
+            self.async_write_ha_state()
+
+        await super().async_added_to_hass()
+        self.topic_update_listener = async_dispatcher_connect(
+            self.hass, self.topic_update, update
+        )
+        self.async_on_remove(self.topic_update_listener)
+        self.update_from_latest_data()
+
+    @property
+    def available(self) -> bool:
+        return not not self.vehicle
+
+    @property
+    def should_poll(self) -> bool:
+        return False
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self.vehicle.id)},
+            "name": self.vehicle.name,
+            "manufacturer": BRANDS[self.vehicle.kia_uvo_api.brand],
+            "model": self.vehicle.model,
+            "engine_type": self.vehicle.engine_type,
+            "sw_version": self.vehicle.registration_date,
+            "via_device": (DOMAIN, self.vehicle.id),
+        }
+
+    @callback
+    def update_from_latest_data(self):
+        self.vehicle = self.hass.data[DOMAIN][DATA_VEHICLE_INSTANCE]
+
+
+
+class KiaUvoSensorEntity(SensorEntity):
     def __init__(self, hass, config_entry, vehicle: Vehicle):
         self.hass = hass
         self.config_entry = config_entry

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -11,9 +11,9 @@ from homeassistant.const import (
 )
 from homeassistant.util import distance as distance_util
 import homeassistant.util.dt as dt_util
-from homeassistant.components.sensor import SensorStateClass
+from homeassistant.components.sensor import SensorStateClass, SensorEntity
 from .Vehicle import Vehicle
-from .KiaUvoEntity import KiaUvoEntity, KiaUvoSensorEntity
+from .KiaUvoEntity import KiaUvoEntity
 from .const import (
     DYNAMIC_TEMP_UNIT,
     REGION_USA,
@@ -292,7 +292,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities(sensors, True)
 
 
-class InstrumentSensor(KiaUvoSensorEntity):
+class InstrumentSensor(KiaUvoEntity, SensorEntity):
     def __init__(
         self,
         hass,

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -11,8 +11,9 @@ from homeassistant.const import (
 )
 from homeassistant.util import distance as distance_util
 import homeassistant.util.dt as dt_util
+from homeassistant.components.sensor import SensorStateClass
 from .Vehicle import Vehicle
-from .KiaUvoEntity import KiaUvoEntity
+from .KiaUvoEntity import KiaUvoEntity, KiaUvoSensorEntity
 from .const import (
     DYNAMIC_TEMP_UNIT,
     REGION_USA,
@@ -45,6 +46,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 PERCENTAGE,
                 "mdi:car-electric",
                 DEVICE_CLASS_BATTERY,
+                SensorStateClass.MEASUREMENT,
             )
         )
         INSTRUMENTS.append(
@@ -55,6 +57,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 DYNAMIC_DISTANCE_UNIT,
                 "mdi:road-variant",
                 None,
+                SensorStateClass.MEASUREMENT,
             )
         )
         INSTRUMENTS.append(
@@ -65,6 +68,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 DYNAMIC_DISTANCE_UNIT,
                 "mdi:road-variant",
                 None,
+                SensorStateClass.MEASUREMENT,
             )
         )
         INSTRUMENTS.append(
@@ -74,6 +78,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 "vehicleStatus.evStatus.remainTime2.atc.value",
                 TIME_MINUTES,
                 "mdi:ev-station",
+                None,
                 None,
             )
         )
@@ -85,6 +90,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 TIME_MINUTES,
                 "mdi:ev-station",
                 None,
+                None,
             )
         )
         INSTRUMENTS.append(
@@ -94,6 +100,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 "vehicleStatus.evStatus.remainTime2.etc2.value",
                 TIME_MINUTES,
                 "mdi:ev-station",
+                None,
                 None,
             )
         )
@@ -105,6 +112,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 TIME_MINUTES,
                 "mdi:ev-station",
                 None,
+                None,
             )
         )
         INSTRUMENTS.append(
@@ -115,6 +123,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 PERCENTAGE,
                 "mdi:car-electric",
                 None,
+                None,
             )
         )
         INSTRUMENTS.append(
@@ -124,6 +133,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 "vehicleStatus.evStatus.targetSOC.0.targetSOClevel",
                 PERCENTAGE,
                 "mdi:car-electric",
+                None,
                 None,
             )
         )
@@ -137,6 +147,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     DYNAMIC_DISTANCE_UNIT,
                     "mdi:ev-station",
                     None,
+                    None,
                 )
             )
             INSTRUMENTS.append(
@@ -146,6 +157,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     "vehicleStatus.evStatus.targetSOC.0.dte.rangeByFuel.totalAvailableRange.value",
                     DYNAMIC_DISTANCE_UNIT,
                     "mdi:ev-station",
+                    None,
                     None,
                 )
             )
@@ -159,6 +171,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 DYNAMIC_DISTANCE_UNIT,
                 "mdi:road-variant",
                 None,
+                None,
             )
         )
     if vehicle.engine_type is VEHICLE_ENGINE_TYPE.IC:
@@ -169,6 +182,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 "vehicleStatus.dte.value",
                 DYNAMIC_DISTANCE_UNIT,
                 "mdi:road-variant",
+                None,
                 None,
             )
         )
@@ -181,6 +195,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             DYNAMIC_DISTANCE_UNIT,
             "mdi:speedometer",
             None,
+            SensorStateClass.TOTAL_INCREASING,
         )
     )
     INSTRUMENTS.append(
@@ -190,6 +205,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             "lastService.value",
             DYNAMIC_DISTANCE_UNIT,
             "mdi:car-wrench",
+            None,
             None,
         )
     )
@@ -201,6 +217,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             DYNAMIC_DISTANCE_UNIT,
             "mdi:car-wrench",
             None,
+            None,
         )
     )
     INSTRUMENTS.append(
@@ -210,6 +227,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             "vehicleLocation.geocodedLocation.display_name",
             None,
             "mdi:map",
+            None,
             None,
         )
     )
@@ -221,6 +239,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             PERCENTAGE,
             "mdi:car-battery",
             DEVICE_CLASS_BATTERY,
+            None,
         )
     )
     INSTRUMENTS.append(
@@ -231,12 +250,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             DYNAMIC_TEMP_UNIT,
             None,
             DEVICE_CLASS_TEMPERATURE,
+            None,
         )
     )
 
     sensors = []
 
-    for id, description, key, unit, icon, device_class in INSTRUMENTS:
+    for id, description, key, unit, icon, device_class, state_class in INSTRUMENTS:
         if vehicle.get_child_value(key) is None:
             _LOGGER.debug(f"skipping sensor for missing data, key:{key}")
         else:
@@ -251,6 +271,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     unit,
                     icon,
                     device_class,
+                    state_class,
                 )
             )
 
@@ -265,12 +286,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             "None",
             "mdi:update",
             DEVICE_CLASS_TIMESTAMP,
+            None,
         )
     )
     async_add_entities(sensors, True)
 
 
-class InstrumentSensor(KiaUvoEntity):
+class InstrumentSensor(KiaUvoSensorEntity):
     def __init__(
         self,
         hass,
@@ -282,6 +304,7 @@ class InstrumentSensor(KiaUvoEntity):
         unit,
         icon,
         device_class,
+        state_class,
     ):
         super().__init__(hass, config_entry, vehicle)
         self._id = id
@@ -291,6 +314,7 @@ class InstrumentSensor(KiaUvoEntity):
         self._source_unit = unit
         self._icon = icon
         self._device_class = device_class
+        self._state_class = state_class
         self._dynamic_distance_unit = False
         if self._unit == DYNAMIC_DISTANCE_UNIT:
             self._dynamic_distance_unit = True
@@ -368,6 +392,10 @@ class InstrumentSensor(KiaUvoEntity):
     @property
     def device_class(self):
         return self._device_class
+
+    @property
+    def state_class(self):
+        return self._state_class
 
     @property
     def name(self):


### PR DESCRIPTION
This PR adds [long term statistics](https://data.home-assistant.io/docs/statistics/) for the following sensors:
- EV Battery
- EV Range
- Total Range
- Odometer

Other (non-EV) sensors might be interesting as well to add as long term statistics in HA, but I am only able to test EV-sensors.
