### PR TITLE
fix: force update scan when start < finish

### DIFF
--- a/custom_components/kia_uvo/__init__.py
+++ b/custom_components/kia_uvo/__init__.py
@@ -199,8 +199,17 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         call_force_update = False
 
         if (
-            ((no_force_scan_hour_start <= no_force_scan_hour_finish) and (event_time_local.hour < no_force_scan_hour_start or event_time_local.hour >= no_force_scan_hour_finish))
-            or ((no_force_scan_hour_start >= no_force_scan_hour_finish) and (event_time_local.hour < no_force_scan_hour_start and event_time_local.hour >= no_force_scan_hour_finish))
+            (no_force_scan_hour_start <= no_force_scan_hour_finish)
+            and (
+                event_time_local.hour < no_force_scan_hour_start
+                or event_time_local.hour >= no_force_scan_hour_finish
+            )
+        ) or (
+            (no_force_scan_hour_start >= no_force_scan_hour_finish)
+            and (
+                event_time_local.hour < no_force_scan_hour_start
+                and event_time_local.hour >= no_force_scan_hour_finish
+            )
         ):
             if (
                 datetime.now(local_timezone) - vehicle.last_updated

--- a/custom_components/kia_uvo/__init__.py
+++ b/custom_components/kia_uvo/__init__.py
@@ -199,8 +199,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         call_force_update = False
 
         if (
-            event_time_local.hour < no_force_scan_hour_start
-            and event_time_local.hour >= no_force_scan_hour_finish
+            ((no_force_scan_hour_start <= no_force_scan_hour_finish) and (event_time_local.hour < no_force_scan_hour_start or event_time_local.hour >= no_force_scan_hour_finish))
+            or ((no_force_scan_hour_start >= no_force_scan_hour_finish) and (event_time_local.hour < no_force_scan_hour_start and event_time_local.hour >= no_force_scan_hour_finish))
         ):
             if (
                 datetime.now(local_timezone) - vehicle.last_updated


### PR DESCRIPTION
This PR fixes the issue when `no_force_scan_hour_start` is smaller than `no_force_scan_hour_finish`.
For example, configuring no force update between 01h00 and 05h00 would result in the forced update _only_ triggering between those hours, in stead of outside the range. 

The `if`-statement now checks whether `no_force_scan_hour_start <= no_force_scan_hour_finish` and applies a slightly different logic.