### PR TITLE
fix: Added HACS minimum HA Version

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "Kia Uvo / Hyundai Bluelink",
   "render_readme": true,
+  "homeassistant": "2021.12",
   "content_in_root": false
 }


### PR DESCRIPTION
Sets the minimum home assistant version required for this to run as we have seen two issues reported due to this.