### PR TITLE
fix: Reduced API calls.

### DIFF
--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -77,7 +77,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
         Allow force update, if time diff between latest update and `now` is greater than force refresh delta
         """
 
-        await self.async_update_all()
+        await self.async_check_and_refresh_token()
         await self.hass.async_add_executor_job(
             self.vehicle_manager.check_and_force_update_vehicles,
             self.force_refresh_interval,
@@ -97,7 +97,6 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
         await self.hass.async_add_executor_job(
             self.vehicle_manager.force_refresh_all_vehicles_states
         )
-        return await self.async_update_all()
 
     async def async_check_and_refresh_token(self):
         """Refresh token if needed via library."""


### PR DESCRIPTION
The last step of a force refresh call in the API is to refresh from the cache as the cache is now current.  Calling it before we force an update just increases API calls.