### PR TITLE
fix: last_updated unit of measurement

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -295,7 +295,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             "lastUpdated",
             "Last Update",
             "last_updated",
-            "None",
+            None,
             "mdi:update",
             DEVICE_CLASS_TIMESTAMP,
             None,


### PR DESCRIPTION
Super minor fix for the unit_of_measurement for last_update. Should not be the string `"None"` but simply state `None` (just like geocodedLocation)

It fixes my InfluxDB measurements 👍