### PR TITLE
fix(US): Correct temperature settings to match the kia UVO app and the vehicle

### DIFF
--- a/custom_components/kia_uvo/Vehicle.py
+++ b/custom_components/kia_uvo/Vehicle.py
@@ -181,7 +181,11 @@ class Vehicle:
 
     async def start_climate(self, set_temp, duration, defrost, climate, heating):
         if set_temp is None:
-            set_temp = 21
+            set_temp = 72
+        elif set_temp < 62: 
+            set_temp = 'LOW'
+        elif set_temp > 82:
+            set_temp = 'HIGH'
         if duration is None:
             duration = 5
         if defrost is None:

--- a/custom_components/kia_uvo/services.yaml
+++ b/custom_components/kia_uvo/services.yaml
@@ -27,17 +27,17 @@ start_climate:
         boolean: 
     Temperature:
       name: Temperature
-      description: Set temperature of climate control. Unit is specific to region. 
+      description: Set temperature of climate control. For US Kia, anything lower than 62 will be translated to 'LOW' and anything higher than 82 will be translated to 'HIGH', in accordance with the official app.
       required: false
-      example: 21.5
-      default: 21
+      example: 72
+      default: 72
       selector:
         number:
-            min: 16
-            max: 85
-            step: 0.5
-            mode: box
-            unit_of_measurement: Degrees
+          min: 60
+          max: 85
+          step: 0.5
+          unit_of_measurement: Degrees
+          mode: slider
     Defrost:
       name: Defrost
       description: Front Windshield Defrost


### PR DESCRIPTION
In the US Kia Telluride (and I assume other US Kia vehicles) as well as the US Kia UVO app, you are only allowed to set the climate temperature to LOW -> 62-82 <- HIGH. I made changes to the services.yaml file to account for this: 1) Changed the default temperature from 21 to 72, 2) The min to 60, 3) And the max to 85. I also added logic in the vehicle.py file to translate anything < 62 to 'LOW', and anything > 82 to 'HIGH'.
