### PR TITLE
feat(EU): EV sensors for average consumption & energy used

### DIFF
--- a/custom_components/kia_uvo/KiaUvoApiEU.py
+++ b/custom_components/kia_uvo/KiaUvoApiEU.py
@@ -486,11 +486,9 @@ class KiaUvoApiEU(KiaUvoApiImpl):
 
         drivingInfo = {}
 
+
         try:
-            for drivingInfoItem in responseAlltime["resMsg"]["drivingInfo"]:
-                if drivingInfoItem["drivingPeriod"] == 0:
-                    drivingInfo = drivingInfoItem
-                    break
+            drivingInfo = responseAlltime["resMsg"]["drivingInfoDetail"][0]
 
             for drivingInfoItem in response30d["resMsg"]["drivingInfo"]:
                 if drivingInfoItem["drivingPeriod"] == 0:

--- a/custom_components/kia_uvo/KiaUvoApiEU.py
+++ b/custom_components/kia_uvo/KiaUvoApiEU.py
@@ -454,9 +454,9 @@ class KiaUvoApiEU(KiaUvoApiImpl):
         _LOGGER.debug(f"{DOMAIN} - get_cached_vehicle_status response {response}")
 
         try:
-            response["resMsg"]["vehicleStatusInfo"]["drvhistory"] = self.get_driving_info(
-                token
-            )
+            response["resMsg"]["vehicleStatusInfo"][
+                "drvhistory"
+            ] = self.get_driving_info(token)
         except:
             _LOGGER.warning("Unable to get drivingInfo")
 
@@ -493,7 +493,8 @@ class KiaUvoApiEU(KiaUvoApiImpl):
             for drivingInfoItem in response30d["resMsg"]["drivingInfo"]:
                 if drivingInfoItem["drivingPeriod"] == 0:
                     drivingInfo["consumption30d"] = round(
-                        drivingInfoItem["totalPwrCsp"] / drivingInfoItem["calculativeOdo"]
+                        drivingInfoItem["totalPwrCsp"]
+                        / drivingInfoItem["calculativeOdo"]
                     )
                     break
 

--- a/custom_components/kia_uvo/KiaUvoApiEU.py
+++ b/custom_components/kia_uvo/KiaUvoApiEU.py
@@ -466,7 +466,9 @@ class KiaUvoApiEU(KiaUvoApiImpl):
         url = self.SPA_API_URL + "vehicles/" + token.vehicle_id + "/drvhistory"
         headers = {
             "Authorization": token.access_token,
-            "Stamp": token.stamp,
+            "ccsp-service-id": self.CCSP_SERVICE_ID,
+            "ccsp-application-id": self.APP_ID,
+            "Stamp": self.get_stamp(),
             "ccsp-device-id": token.device_id,
             "Host": self.BASE_URL,
             "Connection": "Keep-Alive",

--- a/custom_components/kia_uvo/KiaUvoApiEU.py
+++ b/custom_components/kia_uvo/KiaUvoApiEU.py
@@ -486,7 +486,6 @@ class KiaUvoApiEU(KiaUvoApiImpl):
 
         drivingInfo = {}
 
-
         try:
             drivingInfo = responseAlltime["resMsg"]["drivingInfoDetail"][0]
 

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -154,8 +154,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         )
         INSTRUMENTS.append(
             (
-                "totalEnergyConsumption",
-                "Total Energy Consumption",
+                "monthlyEnergyConsumption",
+                "Monthly Energy Consumption",
                 "drvhistory.totalPwrCsp",
                 ENERGY_WATT_HOUR,
                 "mdi:car-electric",
@@ -427,7 +427,7 @@ class InstrumentSensor(KiaUvoEntity, SensorEntity):
                     "vehicleLocation.geocodedLocation.address"
                 )
             }
-        elif self._id == "totalEnergyConsumption":
+        elif self._id == "monthlyEnergyConsumption":
             return {
                 "totalPwrCsp": self.vehicle.get_child_value("drvhistory.totalPwrCsp"),
                 "motorPwrCsp": self.vehicle.get_child_value("drvhistory.motorPwrCsp"),

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -37,6 +37,18 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     INSTRUMENTS = []
 
+    INSTRUMENTS.append(
+        (
+            "fuelLevel",
+            "Fuel Level",
+            "vehicleStatus.fuelLevel",
+            PERCENTAGE,
+            "mdi:fuel",
+            None,
+            SensorStateClass.MEASUREMENT,
+        )
+    )
+
     if (
         vehicle.engine_type is VEHICLE_ENGINE_TYPE.EV
         or vehicle.engine_type is VEHICLE_ENGINE_TYPE.PHEV

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -442,6 +442,9 @@ class InstrumentSensor(KiaUvoEntity, SensorEntity):
                 "calculativeOdo": self.vehicle.get_child_value(
                     "drvhistory.calculativeOdo"
                 ),
+                "drivingDate": ''.join(filter(str.isdigit, self.vehicle.get_child_value(
+                    "drvhistory.drivingDate"
+                ))),
             }
         return None
 

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -165,17 +165,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         )
         INSTRUMENTS.append(
             (
-                "totalEnergyRecuperation",
-                "Total Energy Recuperation",
-                "drvhistory.regenPwr",
-                ENERGY_WATT_HOUR,
-                "mdi:battery-plus-variant",
-                DEVICE_CLASS_ENERGY,
-                SensorStateClass.TOTAL_INCREASING,
-            )
-        )
-        INSTRUMENTS.append(
-            (
                 "averageEnergyConsumption",
                 "Average Energy Consumption",
                 "drvhistory.consumption30d",

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -431,11 +431,17 @@ class InstrumentSensor(KiaUvoEntity, SensorEntity):
             return {
                 "totalPwrCsp": self.vehicle.get_child_value("drvhistory.totalPwrCsp"),
                 "motorPwrCsp": self.vehicle.get_child_value("drvhistory.motorPwrCsp"),
-                "climatePwrCsp": self.vehicle.get_child_value("drvhistory.climatePwrCsp"),
+                "climatePwrCsp": self.vehicle.get_child_value(
+                    "drvhistory.climatePwrCsp"
+                ),
                 "eDPwrCsp": self.vehicle.get_child_value("drvhistory.eDPwrCsp"),
                 "regenPwr": self.vehicle.get_child_value("drvhistory.regenPwr"),
-                "batteryMgPwrCsp": self.vehicle.get_child_value("drvhistory.batteryMgPwrCsp"),
-                "calculativeOdo": self.vehicle.get_child_value("drvhistory.calculativeOdo")
+                "batteryMgPwrCsp": self.vehicle.get_child_value(
+                    "drvhistory.batteryMgPwrCsp"
+                ),
+                "calculativeOdo": self.vehicle.get_child_value(
+                    "drvhistory.calculativeOdo"
+                ),
             }
         return None
 

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -442,9 +442,12 @@ class InstrumentSensor(KiaUvoEntity, SensorEntity):
                 "calculativeOdo": self.vehicle.get_child_value(
                     "drvhistory.calculativeOdo"
                 ),
-                "drivingDate": ''.join(filter(str.isdigit, self.vehicle.get_child_value(
-                    "drvhistory.drivingDate"
-                ))),
+                "drivingDate": "".join(
+                    filter(
+                        str.isdigit,
+                        self.vehicle.get_child_value("drvhistory.drivingDate"),
+                    )
+                ),
             }
         return None
 


### PR DESCRIPTION
This PR adds two sensors for EV's:

- Average Energy Consumption (30 day moving average)
- Total Energy Consumption

The average shows in watt per kilometer (mile) the average usage of the past 30 days.
The total consumption shows in kwh the total energy consumption since the vehicle was connected to Bluelink. This sensor can be used in conjuction with the Home Assistant Energy dashboard as an individual device, allowing one to see daily, weekly, monthly statistics. The sensor also includes as attributes other information such as recuperation energy and climate usage (in watt).

This code has been running for more than a month now in my setup.

There are three considerations:
1. Only tested in EU
2. Only tested with EV. Not sure if the same / comparable api is available for fuel cars
3. It requires two additional api calls. This counts towards the api limit. In my current setup this hasn't been an issue (6 min scan interval / 780 min force update / no black blackout). It is best to only make this call when doing a force update, however I've been unable to figure out to code this in a manageable way. Suggestions are welcome.


![image](https://user-images.githubusercontent.com/3670848/158607714-8c07e3e2-f221-4631-a54c-e7d90677e71e.png)
![image](https://user-images.githubusercontent.com/3670848/158607806-6f1d4a2d-5932-4a7f-a5a0-43f079a93b32.png)
