### PR TITLE
chore: upgrade black to latest version

### DIFF
--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
           - "--py38-plus"
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         stages: [manual]


### PR DESCRIPTION
current workflows are failing because of outdated black