### PR TITLE
Add Charge Port Door binary sensor

### DIFF
--- a/custom_components/kia_uvo/binary_sensor.py
+++ b/custom_components/kia_uvo/binary_sensor.py
@@ -249,6 +249,16 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 DEVICE_CLASS_PLUG,
             )
         )
+        BINARY_INSTRUMENTS.append(
+            (
+                "chargingPortDoor",
+                "Charging Port Door",
+                "vehicleStatus.evStatus.chargePortDoorOpenStatus",
+                "mdi:ev-plug-type2",
+                "mdi:ev-plug-type2",
+                DEVICE_CLASS_DOOR,
+            )
+        )
 
     binary_sensors = []
 
@@ -299,7 +309,10 @@ class InstrumentSensor(KiaUvoEntity):
 
     @property
     def is_on(self) -> bool:
-        return bool(self.vehicle.get_child_value(self.key))
+        if self.id == "chargingPortDoor":
+            return True if self.vehicle.get_child_value(self.key) == 1 else False
+        else:
+            return bool(self.vehicle.get_child_value(self.key))
 
     @property
     def state(self):


### PR DESCRIPTION
Adds a binary sensor for Charge Port door, which Kia EV6 data returns. 
It seems to use 1 for open, and 2 for closed, but I'm not sure if other values are used, rather than just true/false.