### PR TITLE
fix: Don't use device_class battery for 12V battery in v2.0

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -56,7 +56,6 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         name="Car Battery Level",
         icon="mdi:car-battery",
         native_unit_of_measurement=PERCENTAGE,
-        device_class=SensorDeviceClass.BATTERY,
     ),
     SensorEntityDescription(
         key="last_updated_at",


### PR DESCRIPTION
SSIA

As per discussion with @cdnninja 