### PR TITLE
fix: Require heating for start_climate

### DIFF
--- a/custom_components/kia_uvo/services.yaml
+++ b/custom_components/kia_uvo/services.yaml
@@ -70,7 +70,7 @@ start_climate:
     heating:
       name: Heating
       description: Heated features like the steering wheel and rear window
-      required: false
+      required: true
       example: false
       default: false  
       selector:


### PR DESCRIPTION
Require heating setting for start_climate as all regions do require it.  Resolves https://github.com/fuatakgun/kia_uvo/issues/447.